### PR TITLE
Fix spelling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -172,14 +172,14 @@
 	* src/rig-gui-lcd.[ch]:
 	Changed rig_gui_lcd_set_freq_digits and rig_gui_lcd_set_rit_digits
 	to be public in order to allow direct setting of frequency display
-	when managing events other than the ones occuring on the LCD area.
+	when managing events other than the ones occurring on the LCD area.
 	
 	
 
 2007-11-15;	Alexandru Csete <oz9aec@gmail.com>
 
 	* NEWS, TODO:
-	Separate NEWS and future improvments.
+	Separate NEWS and future improvements.
 
 	* src/Makefile.am:
 	Allow build with Gtk+ 2.12 (GtkTooltips deprecated).
@@ -334,7 +334,7 @@
 
 	* src/rig-daemon.c:
 	Sleep between commands only if the last command has been executed.
-	Added hamlib error message when a command failes to execute.
+	Added hamlib error message when a command fails to execute.
 
 	* src/grig-debug:
 	Use local debug level in order to be able to filter grig debug messages
@@ -461,7 +461,7 @@
 	Modified to use grig debug handler instead of the one from Hamlib.
 
 	* src/rig-daemon.c, src/rig-daemon-check.c:
-	Modfied to use grig debug handler and use i18n for strings.
+	Modified to use grig debug handler and use i18n for strings.
 
 	* src/rig-gui-message-window.c:
 	Implemented reading debug messages from log files. Still to do is
@@ -560,7 +560,7 @@
 
 	* src/grig-menubar.c:
 	Added RIG_FUNC and software memory menu entries.
-	Use stock pixmaps where apropriate.
+	Use stock pixmaps where appropriate.
 
 	* src/rig-gui.c:
 	Change lcd box spacing for better layout.
@@ -865,7 +865,7 @@
 	Added command line option for command delay.
 
 	* doc/man/grig.1.in:
-	Added section about comamnd delays and buggy power off
+	Added section about command delays and buggy power off
 	state.
 
 	* Makefile.am:
@@ -1092,7 +1092,7 @@
 
 	* src/grig-gtk-workarounds.c, src/griggtk-workarounds.h:
 	Created files. Intended to contain various workaround tricks for Gtk+
-	bugs and limitations. Currently it contains funtions to allow tooltips
+	bugs and limitations. Currently it contains functions to allow tooltips
 	with the GtkComboBox widget.
 
 	* src/rig-guit-ctrl2.c, src/rig-gui-buttons.c:
@@ -1248,10 +1248,10 @@
 
 	* src/rig-daemon.c:
 	Fixed bug which caused the pass band to be set to 1Hz each time the
-	mode was changed. Replaced XIT comamnds with VFO comamnds.
+	mode was changed. Replaced XIT commands with VFO commands.
 
 	* src/rig-daemon-check.c:
-	Set smeter value to -54dB if comamnd is not available. Added code to
+	Set smeter value to -54dB if command is not available. Added code to
 	storeavailableVFOs in rig-data.
 
 	* src/rig-data-c, src/rig-data.h:
@@ -1327,7 +1327,7 @@
 2004-10-29;	Alexandru Csete - SK568 <csete@uers.sourceforge.net>
 
 	* src/main.c:
-	Removed some useless comments from command line option handlig code and
+	Removed some useless comments from command line option handling code and
 	compressed code a little.
 
 	* NOTE:
@@ -1339,7 +1339,7 @@
 
 	* configure.in:
 	Added --disable-hardware option to disable any hamlib operations except
-	rig_init and rig_cleanup (usefull to test rig caps and such).
+	rig_init and rig_cleanup (useful to test rig caps and such).
 
 	* src/rig-daemon-check.c:
 	Added '\n' to the end of error messages.
@@ -1349,7 +1349,7 @@
 
 	* src/rig-gui-lcd.c:
 	Fixed a bug which caused incorrect RIT jumps especially when the RIT
-	sign chnges (eg. -0.40 + 1.00 gave 0.60 instead of 0.40). Added utility
+	sign changes (eg. -0.40 + 1.00 gave 0.60 instead of 0.40). Added utility
 	function to explicitly convert RIT/XIT values to byte array.
 
 	* configure.in:
@@ -1420,14 +1420,14 @@
 
 	* src/grig-menubar.c, src/grig-menubar.h:
 	Remove rotator and GConf related code. Created menubar using GtkAction
-	achitecture.
+	architecture.
 
 	* src/rig-gui.c:
 	Include menubar in the GUI.
 	
 	* src/main.c:
 	Rearranged some code in the creation of the main window so that the
-	window is ceated before the creation of the menubar.
+	window is created before the creation of the menubar.
 	
 
 2004-10-18;	Alexandru Csete <oz9aec@gmail.com>
@@ -1470,7 +1470,7 @@
 	separator. Modified code to take new pixmaps with '-' into account.
 	Also found and fixed a memory leak in rig_gui_lcd_set_rit_digits.
 	Added function to draw miscellaneous text on the display.
-	Updated design docs accrdingly.
+	Updated design docs accordingly.
 	
 	* pixmaps/digits_normal.png, pixmaps/digits_small.png:
 	Added '-'sign.
@@ -1487,7 +1487,7 @@
 
 	* src/rig-gui-lcd.c:
 	Finished tuning code for both frequency and RIT/XIT. Only RIT is
-	suported at the moment. Also added RIT/XIT mode selection field to
+	supported at the moment. Also added RIT/XIT mode selection field to
 	the main ata structure.
 
 	* src/rig-daemon-check.c:
@@ -1497,7 +1497,7 @@
 2004-10-08;	Alexandru Csete <oz9aec@gmail.com>
 
 	* src/rig-gui-lcd.c:
-	Added more event handlig code to catch mouse events on the LCD
+	Added more event handling code to catch mouse events on the LCD
 	display. Expose event call has been merged into this code.
 	
 
@@ -1505,7 +1505,7 @@
 
 	* src/rig-gui-lcd.c:
 	Added code to display small digits and removed first dot between
-	MHz and kHz (too confusing). Aded RIT/XIT display. Added bug text
+	MHz and kHz (too confusing). Added RIT/XIT display. Added bug text
 	that it does not work with frequencies above 1 GHz.
 
 	* src/rig-data.c, src/rig-data.h:
@@ -1617,7 +1617,7 @@
 	* src/main.c:
 	Removed GNOME dependencies.
 
-	* autogen.sh, Makefile.am, cofigure.in:
+	* autogen.sh, Makefile.am, configure.in:
 	Updated for Gtk+ only.
 	
 	* src/Makefile.am:
@@ -1643,7 +1643,7 @@
 2004-09-26;	Alexandru Csete - SK1563 <oz9aec@gmail.com>
 
 	* src/rig-data.c:
-	rig_data_set functions will temporarely set the 'get' data to 
+	rig_data_set functions will temporarily set the 'get' data to 
 	the 'set' value to avoid gui flip-back when daemon is to slow to
 	update the 'get' variable.
 

--- a/NEWS
+++ b/NEWS
@@ -130,7 +130,7 @@ GRIG 0.4.0:
 - Removed level sliders, will be re-added in the next version.
 
 
-GRIG 0.3.0 (never relesed, available from CVS):
+GRIG 0.3.0 (never released, available from CVS):
 
 - Rotator support with the possibility for AZ, EL or AZ/EL
   rotators.

--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,8 @@ dnl  AC_DEFINE(WANT_HAMLIB, 1)
 ])
 
 
-dnl various developer/devloper options
-dnl diable HW interaction; usefull to access RIG caps without
+dnl various developer/developer options
+dnl disable HW interaction; useful to access RIG caps without
 dnl having rig; default=no
 AC_ARG_ENABLE(hardware, [  --disable-hardware      disable hardware IO],
               [if test "$enableval" = no ; then disable_hadware=yes; else disable_hadware=no; fi],disable_hadware=no)
@@ -72,7 +72,7 @@ fi
 
 dnl compiler flags to enable generating coverage report
 dnl using gcov
-AC_ARG_ENABLE(coverage, [  --enable-coverage       enable coverge reports],enable_coverage="$enableval",enable_coverage=no)
+AC_ARG_ENABLE(coverage, [  --enable-coverage       enable coverage reports],enable_coverage="$enableval",enable_coverage=no)
 if test "$enable_coverage" = yes ; then
         CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage";
 	AC_DEFINE(DISABLE_HW, 1, [Define if hardware is disabled.])

--- a/doc/html/grig.html
+++ b/doc/html/grig.html
@@ -181,7 +181,7 @@ using the -P or --enable-pwr command line switch.
 <DT>PTT Control<DD>
 Similar to the power state, the PTT has caused strange behaviour on some radios.
 Consequently, it has been disabled by default but can be enabled using the -p or
---enable-ptt command line aguments.
+--enable-ptt command line arguments.
 <P>
 </DL>
 <A NAME="lbAH">&nbsp;</A>

--- a/doc/man/grig.1.in
+++ b/doc/man/grig.1.in
@@ -128,7 +128,7 @@ There have been reports on that the new, thread\-based daemon process is never
 started on FreeBSD, while the old, timeout\-based daemon worked fine. It is therefore
 possible to choose the two ways to run the daemon process. The default is the new
 thread based daemon, but if you use FreeBSD and nothing seems to work after start\-up
-you can select the timout\-based daemon with the \-n or \-\-nothread command line option.
+you can select the timeout\-based daemon with the \-n or \-\-nothread command line option.
 .TP
 Connection Settings
 Once you have started grig you can not change the radio settings (model, device,
@@ -159,7 +159,7 @@ using the \-P or \-\-enable\-pwr command line switch.
 PTT Control
 Similar to the power state, the PTT has caused strange behaviour on some radios.
 Consequently, it has been disabled by default but can be enabled using the \-p or
-\-\-enable\-ptt command line aguments.
+\-\-enable\-ptt command line arguments.
 
 .SH "AUTHOR"
 Written by Alexandru Csete, OZ9AEC.

--- a/grig.spec.in
+++ b/grig.spec.in
@@ -11,7 +11,7 @@ Name: %{name}
 Version: %{version}
 Release: %{release}
 Copyright: GPL
-Group: Application/Comunication
+Group: Application/Communication
 Prefix: /usr
 BuildRoot: /var/tmp/%{name}-%{version}
 Summary: Graphical user interface for the Ham Radio Control Libraries

--- a/src/grig-config.c
+++ b/src/grig-config.c
@@ -81,7 +81,7 @@ gint grig_config_check ()
 
 
 /** \brief Check configuration directory.
- *  \return 0 if successful, -1 if an error ocurred.
+ *  \return 0 if successful, -1 if an error occurred.
  *
  * This function checks for the existence of the .grig directory in the
  * user's home folder and creates it if the directory doesn't already exist.
@@ -122,7 +122,7 @@ check_cfg_file ()
 
 
 /** \brief Check version of .rig files and update if necessary
- *  \return 0 if all checks/updates were successful, -1 if an error ocurred
+ *  \return 0 if all checks/updates were successful, -1 if an error occurred
  *
  * This function checks all .rig files in the configuration directory. If the
  * config version is lower than GRIG_RIG_CFG_VER, it tries to update to the
@@ -185,7 +185,7 @@ check_rig_files ()
 
 
 /** \brief Check version of .rot files and update if necessary
- *  \return 0 if all checks/updates were successful, -1 if an error ocurred
+ *  \return 0 if all checks/updates were successful, -1 if an error occurred
  *
  * This function checks all .rot files in the configuration directory. If the
  * config version is lower than GRIG_ROT_CFG_VER, it tries to update to the
@@ -207,7 +207,7 @@ check_rot_files ()
 
 
 /** \brief Check version of .mem files and update if necessary
- *  \return 0 if all checks/updates were successful, -1 if an error ocurred
+ *  \return 0 if all checks/updates were successful, -1 if an error occurred
  *
  * This function checks all .mem files in the configuration directory. If the
  * config version is lower than GRIG_MEM_CFG_VER, it tries to update to the

--- a/src/grig-menubar.c
+++ b/src/grig-menubar.c
@@ -88,7 +88,7 @@ static GtkActionEntry entries[] = {
 
 /** \brief Radio items for selectinghamlib debug level. */
 static GtkRadioActionEntry radio_entries[] = {
-  { "None",    NULL, N_("_No Debug"), NULL, N_("Don't show any debug mesages"),                0 },
+  { "None",    NULL, N_("_No Debug"), NULL, N_("Don't show any debug messages"),                0 },
   { "Bug",     NULL, N_("_Bug"),      NULL, N_("Show error messages caused by possible bugs"), 1 },
   { "Error",   NULL, N_("_Error"),    NULL, N_("Show run-time error messages"),                2 },
   { "Warn",    NULL, N_("_Warning"),  NULL, N_("Show warnings"),                               3 },

--- a/src/key-press-handler.c
+++ b/src/key-press-handler.c
@@ -92,7 +92,7 @@ snooper (GtkWidget *grab_widget, GdkEventKey *event, gpointer func_data)
         stop_processing = TRUE;
         break;
 
-        /* Arrow Left: Descrease frequency with lowest step */
+        /* Arrow Left: Decrease frequency with lowest step */
     case GDK_Left:
 
         if (event->type == GDK_KEY_PRESS) {

--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,7 @@ GtkWidget    *grigapp;
     not in this baseline anyway.
  */
 static gint     rignum    = 0;       /*!< Flag indicating which radio to use.*/
-static gchar   *rigfile   = NULL;    /*!< The port where the rig is atached. */
+static gchar   *rigfile   = NULL;    /*!< The port where the rig is attached. */
 static gchar   *civaddr   = NULL;    /*!< CI-V address for ICOM rig. */
 static gchar   *rigconf   = NULL;    /*!< Configuration parameter. */
 static gint     rigspeed  = 0;       /*!< Optional serial speed. */
@@ -133,7 +133,7 @@ static void        grig_sig_handler    (int sig);
 /** \bief Main program execution entry.
  *  \param argc The number o command line arguments.
  *  \param argv List of command line arguments.
- *  \return Execution status (non-zero mean error ocurred).
+ *  \return Execution status (non-zero mean error occurred).
  *
  * Some description.
  *
@@ -413,7 +413,7 @@ main (int argc, char *argv[])
 
 
 /** \brief Create and initialize main application window.
- *  \param rignum The index of the radio wich is controled by the app
+ *  \param rignum The index of the radio which is controlled by the app
  *  \return A new GtkWindow widget.
  *
  * This function creates and initializes a new GtkWindow which can be used
@@ -498,7 +498,7 @@ static void grig_sig_handler (int sig)
  * This function handles the delete event received by the main application
  * window (eg. when the window is closed by the WM). This function simply
  * returns FALSE indicating that the main application window should be
- * destroyed by emiting the destroy signal.
+ * destroyed by emitting the destroy signal.
  *
  */
 static gint
@@ -648,7 +648,7 @@ grig_show_version   ()
 
 /** \brief List rigs.
  *
- * This function lists the radios suported by hamlib. It shows the
+ * This function lists the radios supported by hamlib. It shows the
  * manufacturer, model, driver version and driver status in a list
  * sorted by model number.
  *
@@ -716,7 +716,7 @@ grig_list_rigs ()
 
 
 /** \brief Add new entry to list of radios.
- *  \param caps Structure with the capablities of thecurrent radio.
+ *  \param caps Structure with the capabilities of thecurrent radio.
  *  \param array Pointer to the GArray into which the new entry should be 
  *               stored.
  *  \return Always 1 to keep rig_list_foreach running.

--- a/src/rig-anomaly.c
+++ b/src/rig-anomaly.c
@@ -37,7 +37,7 @@
  * This object manages the anomalies and errors that occur during communication
  * with the radio. The rig-daemon process raises a specific anomaly every time
  * the execution of a command does not succeed. The anomaly manager will then record the
- * anomaly and, if the same anomaly has occured repeatedly within a certain time period,
+ * anomaly and, if the same anomaly has occurred repeatedly within a certain time period,
  * disable the erroneous command. Therefore, this object needs access to the rig-data API.
  * Furthermore, in order to know about the various rig commands, this object needs
  * access to the rig-daemon data types as well.
@@ -111,10 +111,10 @@ static const anomaly_period_t ANOMALY_COUNT_PERIOD = {
 };
 
 
-/** \brief The anomaly occurence table.
+/** \brief The anomaly occurrence table.
  *
  * This table holds the accumulated number of anomalies
- * that have occured within a certain time period.
+ * that have occurred within a certain time period.
  */
 static anomaly_count_t ANOMALY_COUNT = {
 	0,      /*  RIG_CMD_NONE          */
@@ -142,7 +142,7 @@ static anomaly_count_t ANOMALY_COUNT = {
 
 /** \brief First occurrence of an anomaly.
  *
- * This table holds the time of the first occurence of a given anomaly.
+ * This table holds the time of the first occurrence of a given anomaly.
  */
 static anomaly_time_t FIRST_ANOMALY = {
 	0,      /*  RIG_CMD_NONE          */
@@ -185,7 +185,7 @@ void
 rig_anomaly_raise (rig_cmd_t cmd)
 {
 
-	/* check whether it is the first occurence */
+	/* check whether it is the first occurrence */
 	if ((ANOMALY_COUNT[cmd] == 0) || (FIRST_ANOMALY[cmd] == 0)) {
 
 		/* first occurrence */

--- a/src/rig-daemon-check.c
+++ b/src/rig-daemon-check.c
@@ -184,7 +184,7 @@ rig_daemon_check_vfo     (RIG               *myrig,
  * This function tests whether the rig is capable to get/set the frequency. 
  * The test is done by checking the get_freq and set_freq pointers in the
  * rig_caps structure. Furthermore, if the rig is capable of getting the
- * frequency, the curent frequency is read.
+ * frequency, the current frequency is read.
  */
 void
 rig_daemon_check_freq     (RIG               *myrig,
@@ -203,7 +203,7 @@ rig_daemon_check_freq     (RIG               *myrig,
 	
 
 	if (has_get->freq1) {
-		/* try to obtain current frequncy */
+		/* try to obtain current frequency */
 		retcode = rig_get_freq (myrig, RIG_VFO_CURR, &freq);
 		if (retcode == RIG_OK) {
 			get->freq1 = freq;

--- a/src/rig-daemon.c
+++ b/src/rig-daemon.c
@@ -39,7 +39,7 @@
  *
  * After initialization of the radio it starts a cyclic thread which will
  * execute some pre-defined commands. Because some manufacturers discourage
- * agressive polling while in TX mode, the daemon will only acquire very
+ * aggressive polling while in TX mode, the daemon will only acquire very
  * few things while in this mode.
  *
  * More about cycles and periods...
@@ -497,7 +497,7 @@ rig_daemon_start       (int          rigid,
 		return 1;
 	}
 
-	/* use dummy backend if no ID pecified */
+	/* use dummy backend if no ID specified */
 	if (!rigid) {
 		rigid = 1;
 	}
@@ -523,7 +523,7 @@ rig_daemon_start       (int          rigid,
 			  _("%s: Initializing rig (id=%d)"),
 			  __FUNCTION__, rigid);
 
-	/* initilize rig */
+	/* initialize rig */
 	myrig = rig_init (rigid);
 
 	if (myrig == NULL) {
@@ -608,7 +608,7 @@ rig_daemon_start       (int          rigid,
 #endif
 
 	grig_debug_local (RIG_DEBUG_TRACE,
-			  _("%s: Init successfull, executing post-init"),
+			  _("%s: Init successful, executing post-init"),
 			  __FUNCTION__);
 
 	/* get capabilities and settings  */
@@ -1115,7 +1115,7 @@ rig_daemon_cycle_cb  (gpointer data)
  * This function is responsible for the execution of the specified rig command.
  * First, it checks whether the command is supported by the current radio, if yes,
  * it executes the corresponding hamlib API call. If the command execution is not
- * successfull, an anomaly report is sent to the rig error manager which will take
+ * successful, an anomaly report is sent to the rig error manager which will take
  * care of any further actions like disabling repeatedly failing commands.
  *
  * \note The 'get' commands use local buffers for the acquired value and do not

--- a/src/rig-daemon.h
+++ b/src/rig-daemon.h
@@ -42,7 +42,7 @@
 
 
 #define C_RIG_DAEMON_STOP_TIMEOUT 10000  /*!< Timeout to let the daemon process stop [msec] */
-#define C_RIG_DAEMON_STOP_SLEEP_TIME 100 /*!< Time to sleep between succesive attempts to cheack the clear flag. [msec] */
+#define C_RIG_DAEMON_STOP_SLEEP_TIME 100 /*!< Time to sleep between successive attempts to cheack the clear flag. [msec] */
 
 
 /** \brief List of available commands.

--- a/src/rig-data.c
+++ b/src/rig-data.c
@@ -536,7 +536,7 @@ rig_data_get_freq    (int num)
 	case 1: return get.freq1;
 		break;
 
-		/* secondary frequenct */
+		/* secondary frequency */
 	case 2: return get.freq2;
 		break;
 
@@ -548,7 +548,7 @@ rig_data_get_freq    (int num)
 }
 
 
-/** \brief Get lower freqency limit.
+/** \brief Get lower frequency limit.
  *  \return The current lower frequency limit.
  *
  * This function returns the lower frequency limit which applies to
@@ -562,7 +562,7 @@ rig_data_get_fmin     ()
 
 
 
-/** \brief Get upper freqency limit.
+/** \brief Get upper frequency limit.
  *  \return The current upper frequency limit.
  *
  * This function returns the upper frequency limit which applies to
@@ -1242,7 +1242,7 @@ rig_data_get_split ()
  *  \return A pointer to the shared data.
  *
  * This function is used to obtain the address of the 'get' global data.
- * This is primarly used by the radio daemon for fast access to the data
+ * This is primarily used by the radio daemon for fast access to the data
  * structure.
  */
 grig_settings_t  *
@@ -1257,7 +1257,7 @@ rig_data_get_get_addr ()
  *  \return A pointer to the shared data.
  *
  * This function is used to obtain the address of the 'set' global data.
- * This is primarly used by the radio daemon for fast access to the data
+ * This is primarily used by the radio daemon for fast access to the data
  * structure.
  */
 grig_settings_t  *
@@ -1272,7 +1272,7 @@ rig_data_get_set_addr ()
  *  \return A pointer to the shared data.
  *
  * This function is used to obtain the address of the 'new' global data.
- * This is primarly used by the radio daemon for fast access to the data
+ * This is primarily used by the radio daemon for fast access to the data
  * structure.
  */
 grig_cmd_avail_t *
@@ -1287,7 +1287,7 @@ rig_data_get_new_addr ()
  *  \return A pointer to the shared data.
  *
  * This function is used to obtain the address of the 'has_set' global data.
- * This is primarly used by the radio daemon for fast access to the data
+ * This is primarily used by the radio daemon for fast access to the data
  * structure.
  */
 grig_cmd_avail_t *
@@ -1302,7 +1302,7 @@ rig_data_get_has_set_addr ()
  *  \return A pointer to the shared data.
  *
  * This function is used to obtain the address of the 'has_get' global data.
- * This is primarly used by the radio daemon for fast access to the data
+ * This is primarily used by the radio daemon for fast access to the data
  * structure.
  */
 grig_cmd_avail_t *
@@ -1329,7 +1329,7 @@ rig_data_get_all_antennas    ()
 }
 
 
-/** \brief Store tha maximum RF power level */
+/** \brief Store the maximum RF power level */
 void
 rig_data_set_max_rfpwr (float maxpow)
 {

--- a/src/rig-data.h
+++ b/src/rig-data.h
@@ -36,10 +36,10 @@
  *   \ingroup shdata
  *   \brief   Data type definitions for shared rig data.
  *
- * This file containes the data type definitions for the shared rig data
+ * This file contains the data type definitions for the shared rig data
  * object.
  *
- * \bug packege is incomplete!
+ * \bug package is incomplete!
  *
  * \bug tx meter levels are not ok... need response from hamlib
  */
@@ -126,7 +126,7 @@ typedef struct {
 	/* more or less constant values */
 	freq_t          fmin;      /*!< Lower frequency limit for current mode. */
 	freq_t          fmax;      /*!< Upper frequency limit for current mode. */
-	shortfreq_t     fstep;     /*!< Smallest freqency step for current mode. */
+	shortfreq_t     fstep;     /*!< Smallest frequency step for current mode. */
 	shortfreq_t     ritmax;    /*!< Absolute max RIT. */
 	shortfreq_t     ritstep;   /*!< Smallest RIT step. */
 	shortfreq_t     xitmax;    /*!< Absolute max XIT. */
@@ -230,7 +230,7 @@ int  rig_data_get_all_modes    (void);
 int  rig_data_get_all_antennas (void);
 
 
-/* FIXME: group functions accoring to functionality */
+/* FIXME: group functions according to functionality */
 
 /* set functions */
 void rig_data_set_pstat   (powerstat_t);

--- a/src/rig-gui-info.c
+++ b/src/rig-gui-info.c
@@ -141,7 +141,7 @@ rig_gui_info_run ()
 /** \brief Create header.
  *  \return The header widget which can be packed into themain container.
  *
- * This funcion creates the header of the radio info dialog. The header
+ * This function creates the header of the radio info dialog. The header
  * consists of the brand, model and driver info. The text is arranged in a
  * table with 3 rows and 2 columns. The brand and model is placed in the
  * upper row, the driver version is in the middle row and the driver status
@@ -320,7 +320,7 @@ rig_gui_info_create_offset_frame ()
  * This function creates the widget used to display the set and get
  * level availabilities. The various levels are listed in a vertical
  * table and for each of them a label indicates
- * whether the level is available or not (actualy one label for read and
+ * whether the level is available or not (actually one label for read and
  * one for write).
  *
  *             READ    WRITE
@@ -951,7 +951,7 @@ rig_gui_info_create_frontend_frame ()
  * This function creates the widget used to display the set and get
  * special function availabilities. The various functions are listed in a vertical
  * table and for each of them a label indicates
- * whether the function is available or not (actualy one label for read and
+ * whether the function is available or not (actually one label for read and
  * one for write).
  *
  *             READ    WRITE

--- a/src/rig-gui-lcd.c
+++ b/src/rig-gui-lcd.c
@@ -33,7 +33,7 @@
  *  \ingroup lcd
  *  \brief LCD display.
  *
- * The main pupose of the LCD display widget is to show the current frequency
+ * The main purpose of the LCD display widget is to show the current frequency
  * and to provide easy access to set the current working frequency. The display
  * has 6 large digits left of the decmal and three small digits right of the
  * decimal. It is therefore capable to display the frequency with 1 Hz of 
@@ -146,7 +146,7 @@ static void           rig_gui_lcd_update_vfo       (void);
  *  \return The LCD display widget.
  *
  * This function creates and initializes the LCD display widget which is
- * used to diplay the frequency.
+ * used to display the frequency.
  */
 GtkWidget *
 rig_gui_lcd_create ()
@@ -945,7 +945,7 @@ rig_gui_lcd_calc_dim    ()
  * will be 1 kHz
  *
  * \note The function is optimized in the sense that before drawing of each digit
- * it is checked whether the new digit is different from the one already beeing
+ * it is checked whether the new digit is different from the one already being
  * displayed.
  *
  * \bug 'default' case should send a critical error message.
@@ -977,7 +977,7 @@ rig_gui_lcd_set_freq_digits  (freq_t freq)
 	str = g_strdup_printf ("%10.0f", freq);
 
 	/* for each digit check whether the new digit is different from the one
-	   already beeing displayed; if yes, draw the new digit, otherwise do
+	   already being displayed; if yes, draw the new digit, otherwise do
 	   nothing.
 	*/
 
@@ -1160,7 +1160,7 @@ rig_gui_lcd_clear_manual_entry  (void)
  * string with 3 digits with 0.01 kHz resolution.
  *
  * \note The function is optimized in the sense that before drawing of each digit
- * it is checked whether the new digit is different from the one already beeing
+ * it is checked whether the new digit is different from the one already being
  * displayed.
  *
  * \bug 'default' case should send a critical error message.
@@ -1221,7 +1221,7 @@ rig_gui_lcd_set_rit_digits   (shortfreq_t freq)
 	}
  
 	/* for each digit check whether the new digit is different from the one
-	   already beeing displayed; if yes, draw the new digit, otherwise do
+	   already being displayed; if yes, draw the new digit, otherwise do
 	   nothing.
 	*/
 	for (i=1; i<4; i++) {

--- a/src/rig-gui-lcd.h
+++ b/src/rig-gui-lcd.h
@@ -51,7 +51,7 @@
 /** \brief Green component of the default background (189 in 8 bit). */
 #define LCD_BG_DEFAULT_GREEN  48544
 
-/** \brief Blue componentof te default background (226 in 8 bit). */
+/** \brief Blue component of the default background (226 in 8 bit). */
 #define LCD_BG_DEFAULT_BLUE   57996
 
 

--- a/src/rig-gui-message-window.c
+++ b/src/rig-gui-message-window.c
@@ -196,7 +196,7 @@ rig_gui_message_window_init  ()
  * This function cleans up the message window by freeing the allocated
  * memory. It should be called when the main program exits.
  *
- * Note: It is not strictly neccessary to call this function, since it
+ * Note: It is not strictly necessary to call this function, since it
  *       is also invoked by the 'destroy' callback of the window.
  *
  * FIXME: In the above case this function is not necessary at all.
@@ -494,7 +494,7 @@ read_debug_file (const gchar *filename)
 
 			errorcode = 0;
 
-			/* Close IO chanel; don't care about status.
+			/* Close IO channel; don't care about status.
 			   Shutdown will flush the stream and close the channel
 			   as soon as the reference count is dropped. Order matters!
 			*/
@@ -503,7 +503,7 @@ read_debug_file (const gchar *filename)
 
 		}
 		else {
-			/* an error occured */
+			/* an error occurred */
 
 			grig_debug_local (RIG_DEBUG_ERR,
 					  _("%s:%d: Error open debug log (%s)"),

--- a/src/rig-gui-smeter-conv.c
+++ b/src/rig-gui-smeter-conv.c
@@ -103,7 +103,7 @@
  *
  * This function convertsthe signal strength in dB, as received from hamlib,
  * to the needle angle. The valid range in -54..30, with -54dB corresponding to
- * S0 and 30dB coresponding to S9+30. Values outside range will be truncated to
+ * S0 and 30dB corresponding to S9+30. Values outside range will be truncated to
  * the corresponding limit.
  * \verbatim
          S    dB   deg
@@ -254,7 +254,7 @@ convert_valf_to_angle    (gfloat valf)
  *  \param coor  Coordinate structurewhere the result is stored.
  *
  *  This function converts the needle angle and calculates the two (x,y)
- *  cordinates necessary to draw the needle on the canvas. In order to do
+ *  coordinates necessary to draw the needle on the canvas. In order to do
  *  this the size of the canvas and information about the pixmap is needed.
  *  These are given byconstants in this file and must be adjustedin case
  *  of a new pixmap.

--- a/src/rig-gui-smeter.c
+++ b/src/rig-gui-smeter.c
@@ -216,7 +216,7 @@ rig_gui_smeter_create_canvas ()
     smeter.pixbuf = gdk_pixbuf_new_from_file (fname, NULL);
     g_free (fname);
 
-    /* get initial cordinates */
+    /* get initial coordinates */
     convert_angle_to_rect (smeter.value, &coor);
                            
 }
@@ -441,7 +441,7 @@ rig_gui_mode_selector_create  ()
 /** \brief Create scale selector widget.
  *  \return The scale selector widget.
  *
- * This function is used to create the combo box whih can be used to select the
+ * This function is used to create the combo box which can be used to select the
  * scale/range of the s-meter in TX mode.
  */
 static GtkWidget *
@@ -590,7 +590,7 @@ rig_gui_smeter_expose_cb   (GtkWidget      *widget,
 
 /** \brief Check whether a specific TX mode is available.
  *  \param The TX mode; should be one of smeter_tx_mode_t.
- *  \return A boolean indicationg whether the TX mode is available or not.
+ *  \return A boolean indicating whether the TX mode is available or not.
  *
  */
 static gboolean

--- a/src/rig-gui-smeter.h
+++ b/src/rig-gui-smeter.h
@@ -84,7 +84,7 @@ typedef enum {
 
 /** \brief TX mode setting.
  *
- * These valuesare used to select the meter isplay mode when the rig is
+ * These values are used to select the meter display mode when the rig is
  * in TX mode.
  */
 typedef enum {

--- a/src/rig-gui-vfo.c
+++ b/src/rig-gui-vfo.c
@@ -271,7 +271,7 @@ rig_gui_vfo_eq_cb (GtkWidget *widget, gpointer data)
                  rig_data_has_get_vfo ()) {
 
         grig_debug_local (RIG_DEBUG_BUG,
-                  "%s: VFO COPY without RIG_OP_COPY not imlemented\n",
+                  "%s: VFO COPY without RIG_OP_COPY not implemented\n",
                   __FUNCTION__);
 
     }
@@ -342,7 +342,7 @@ rig_gui_vfo_xchg_cb (GtkWidget *widget, gpointer data)
                  rig_data_has_get_vfo ()) {
 
         grig_debug_local (RIG_DEBUG_BUG,
-                  "%s: VFO XCHG without RIG_OP_XCHG not imlemented\n",
+                  "%s: VFO XCHG without RIG_OP_XCHG not implemented\n",
                   __FUNCTION__);
 
     }

--- a/src/rig-gui.c
+++ b/src/rig-gui.c
@@ -145,7 +145,7 @@ rig_gui_create ()
 			    FALSE, FALSE, 0);
     gtk_widget_show (hbox);
 
-	/* ceate main vertical box */
+	/* create main vertical box */
 	vbox = gtk_vbox_new (FALSE, 0);
 	gtk_box_pack_start (GTK_BOX (vbox), grig_menubar_create (),
 			    FALSE, FALSE, 0);

--- a/src/rig-selector.c
+++ b/src/rig-selector.c
@@ -89,7 +89,7 @@ rig_selector_execute ()
     GtkWidget   *window;   /* the main rig-selector window */
     gchar       *icon;     /* window icon file name */
     GtkWidget   *vbox;     /* the main vertical box in the window */
-    GtkWidget   *butbox1;  /* The button box with New, edit, and delete butons */
+    GtkWidget   *butbox1;  /* The button box with New, edit, and delete buttons */
     GtkWidget   *butbox2;  /* the button box in the bottom of the window */
     GtkWidget   *conbut;   /* Connect button */
     GtkWidget   *cancbut;  /* Cancel button */
@@ -344,7 +344,7 @@ static GtkTreeModel *create_model ()
                     
                 }
                 
-                /* clean up memmory */
+                /* clean up memory */
                 //g_free (buff);
                 
                 if (conf.name)
@@ -379,7 +379,7 @@ static GtkTreeModel *create_model ()
  * This function handles the delete event received by the rig selector
  * window (eg. when the window is closed by the WM). This function simply
  * returns FALSE indicating that the main application window should be
- * destroyed by emiting the destroy signal.
+ * destroyed by emitting the destroy signal.
  *
  */
 static gint

--- a/src/rig-state.c
+++ b/src/rig-state.c
@@ -392,7 +392,7 @@ rig_state_load (const gchar *file)
 	gint               vali;
 	gboolean           valb;
 	gboolean           errorflag = 0;
-	gboolean           loadstate = 1;  /* flag to indicate whether to laod state */
+	gboolean           loadstate = 1;  /* flag to indicate whether to load state */
 
 
 
@@ -745,7 +745,7 @@ ask_cfm (gint state_id, gint rig_id)
  *  \param key The name of the configuiration key.
  *  \param param Pointer to the parameter where the value should be stored.
  *  \param newflag Pointer to the new flag of the parameter.
- *  \return TRUE if an error has occured during read, FALSE otherwise.
+ *  \return TRUE if an error has occurred during read, FALSE otherwise.
  *
  *  \note Float type values are usually levels and constrained to [0.0;1.0]
  *        freq_t is double :P
@@ -804,7 +804,7 @@ read_and_check_level (GKeyFile    *cfgdata,
  *  \param key The name of the configuiration key.
  *  \param param Pointer to the parameter where the value should be stored.
  *  \param newflag Pointer to the new flag of the parameter.
- *  \return TRUE if an error has occured during read, FALSE otherwise.
+ *  \return TRUE if an error has occurred during read, FALSE otherwise.
  */
 static gboolean
 read_and_check_double (GKeyFile    *cfgdata,
@@ -849,7 +849,7 @@ read_and_check_double (GKeyFile    *cfgdata,
  *  \param key The name of the configuiration key.
  *  \param param Pointer to the parameter where the value should be stored.
  *  \param newflag Pointer to the new flag of the parameter.
- *  \return TRUE if an error has occured during read, FALSE otherwise.
+ *  \return TRUE if an error has occurred during read, FALSE otherwise.
  */
 static gboolean read_and_check_int (GKeyFile    *cfgdata,
 				    const gchar *group,
@@ -889,7 +889,7 @@ static gboolean read_and_check_int (GKeyFile    *cfgdata,
  *  \param key The name of the configuiration key.
  *  \param param Pointer to the parameter where the value should be stored.
  *  \param newflag Pointer to the new flag of the parameter.
- *  \return TRUE if an error has occured during read, FALSE otherwise.
+ *  \return TRUE if an error has occurred during read, FALSE otherwise.
  */
 static gboolean read_and_check_bool (GKeyFile    *cfgdata,
 				     const gchar *group,


### PR DESCRIPTION
This PR fixes some spelling errors in the documentation:

- [ChangeLog](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-91c5b46dc84a94604a4e4d0caed9bf85590a2eddbb12d2e8dc80badf324a9dfb)

- [NEWS](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-7ee66c4f1536ac84dc5bbff1b8312e2eef24b974b3e48a5c5c2bcfdf2eb8f3ce)

- [doc/html/grig.html](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-7bcfd4bc37f1f25091b253f302f2af9b23db9593b08a61d33f41ef1ef13ab0cf)
-  [doc/man/grig.1.in](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-4da68610bd3132ef71cb36645e47ded675b5a299daa74a7cfaf16bcc8d53f4a1)
-  [grig.spec.in](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-64e12ac677fc8d1b7e9e32ce527b00d274714b82b196eca8e3b06b1b59d44cd2)

and these are the only user-visible changes in the code:
- [src/grig-menubar.c](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-561edd90cf392d1933697af5689a3fd32fa6cf9fc68fc63a26d6dc59f0a2ad85)
- [src/rig-gui-vfo.c](https://github.com/fillods/grig/compare/master...dforsi:grig:fix/typos?expand=1#diff-dc7791b5194aa666e6a40e444fc9e1c2fa49e2c4357182c5ddbcfb937ac946c7)

Some other changes are in the Doxygen comments and in plain comments.

Let me know if you prefer not to change the Changelog and the NEWS files (those changes look harmless to me).

Fixed with:
codespell --skip=po --write-changes
codespell --skip=po --write-changes --interactive=2