### PR TITLE
Add missing calls to _( )

### DIFF
--- a/src/rig-gui-info.c
+++ b/src/rig-gui-info.c
@@ -454,7 +454,7 @@ rig_gui_info_create_if_frame      ()
 	    (myrig->caps->port_type <= RIG_PORT_PARALLEL)) {
 		
 		gtk_label_set_text (GTK_LABEL (label),
-				    RIG_PORT_STR[myrig->caps->port_type]);
+				    _(RIG_PORT_STR[myrig->caps->port_type]));
 	}
 	else {
 		gtk_label_set_text (GTK_LABEL (label), _("Unknown"));
@@ -483,7 +483,7 @@ rig_gui_info_create_if_frame      ()
 	    (myrig->caps->dcd_type <= RIG_DCD_PARALLEL)) {
 		
 		gtk_label_set_text (GTK_LABEL (label),
-				    DCD_TYPE_STR[myrig->caps->dcd_type]);
+				    _(DCD_TYPE_STR[myrig->caps->dcd_type]));
 	}
 	else {
 		gtk_label_set_text (GTK_LABEL (label), _("Unknown"));
@@ -512,7 +512,7 @@ rig_gui_info_create_if_frame      ()
 	    (myrig->caps->ptt_type <= RIG_PTT_PARALLEL)) {
 		
 		gtk_label_set_text (GTK_LABEL (label),
-				    PTT_TYPE_STR[myrig->caps->dcd_type]);
+				    _(PTT_TYPE_STR[myrig->caps->dcd_type]));
 	}
 	else {
 		gtk_label_set_text (GTK_LABEL (label), _("Unknown"));
@@ -626,7 +626,7 @@ rig_gui_info_create_if_frame      ()
 		    (myrig->caps->serial_parity <= RIG_PARITY_EVEN)) {
 		
 			gtk_label_set_text (GTK_LABEL (label),
-					    RIG_PARITY_STR[myrig->caps->serial_parity]);
+					    _(RIG_PARITY_STR[myrig->caps->serial_parity]));
 		}
 		else {
 			gtk_label_set_text (GTK_LABEL (label), _("Unknown"));


### PR DESCRIPTION
Makes visible the translations for the values of "Port Typ", "DCD Type" and "PTT Type".

Fixes the issue of English values visible in the Radio / Info menu, "Interface" pane even if the corresponding strings are translated:
![image](https://user-images.githubusercontent.com/1055635/210666689-5b0cd073-ecab-4f49-b172-20e43b8f92db.png) English locale
![image](https://user-images.githubusercontent.com/1055635/210666458-9c820736-d36d-486c-8c94-17417ae9eff9.png) Italian locale before this patch
![image](https://user-images.githubusercontent.com/1055635/210670224-76b0e92d-b1e9-4566-8480-ebdcbfd0850e.png) Italian locale after this patch
