### PR TITLE
Bump gtk2 to 2.24

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ if test "${ac_cv_c_compiler_gnu}" = "yes"; then
   CFLAGS="${CFLAGS} -Wall"
 fi
 
-pkg_modules="gtk+-2.0 >= 2.12.0 gthread-2.0 >= 2.14.0"
+pkg_modules="gtk+-2.0 >= 2.24.0 gthread-2.0 >= 2.14.0"
 PKG_CHECK_MODULES(PACKAGE, [$pkg_modules])
 AC_SUBST(PACKAGE_CFLAGS)
 AC_SUBST(PACKAGE_LIBS)


### PR DESCRIPTION
Bump GTK2 to 2.24, this gives us access to some newer functions that were carried across to GTK3 which will help with our efforts on the GTK 3 migration @ #13.