### PR TITLE
Convert gtk_combo_box to gtk_combo_box_text

### DIFF
--- a/src/rig-gui-buttons.c
+++ b/src/rig-gui-buttons.c
@@ -278,10 +278,10 @@ rig_gui_buttons_create_att_selector    ()
     gchar     *text;
     gint       sigid;
 
-    att = gtk_combo_box_new_text ();
-                
+    att = gtk_combo_box_text_new ();
+
     /* add ATT OFF ie. 0 dB */
-    gtk_combo_box_append_text (GTK_COMBO_BOX (att), _("ATT OFF"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (att), _("ATT OFF"));
 
     /* note: HAMLIB_MAXDBLSTSIZ is defined in hamlib; it is the max size of the
         ATT and preamp arrays.
@@ -289,7 +289,7 @@ rig_gui_buttons_create_att_selector    ()
     while ((i < HAMLIB_MAXDBLSTSIZ) && rig_data_get_att_data (i)) {
 
         text = g_strdup_printf ("-%d dB", rig_data_get_att_data (i));
-        gtk_combo_box_append_text (GTK_COMBO_BOX (att), text);
+        gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (att), text);
         g_free (text);
         i++;
     }
@@ -338,10 +338,10 @@ rig_gui_buttons_create_preamp_selector    ()
     gchar     *text;
     gint       sigid;
 
-    preamp = gtk_combo_box_new_text ();
-                
+    preamp = gtk_combo_box_text_new ();
+
     /* add ATT OFF ie. 0 dB */
-    gtk_combo_box_append_text (GTK_COMBO_BOX (preamp), _("PREAMP OFF"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (preamp), _("PREAMP OFF"));
 
     /* note: HAMLIB_MAXDBLSTSIZ is defined in hamlib; it is the max size of the
         ATT and preamp arrays.
@@ -349,7 +349,7 @@ rig_gui_buttons_create_preamp_selector    ()
     while ((i < HAMLIB_MAXDBLSTSIZ) && rig_data_get_preamp_data (i)) {
 
         text = g_strdup_printf ("%d dB", rig_data_get_preamp_data (i));
-        gtk_combo_box_append_text (GTK_COMBO_BOX (preamp), text);
+        gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (preamp), text);
         g_free (text);
         i++;
     }

--- a/src/rig-gui-ctrl2.c
+++ b/src/rig-gui-ctrl2.c
@@ -196,20 +196,20 @@ rig_gui_ctrl2_create ()
 static GtkWidget *
 rig_gui_ctrl2_create_agc_selector    ()
 {
-    GtkWidget         *combo;
-    gint               sigid;
+    GtkWidget *combo;
+    gint       sigid;
 
 
     /* create and initialize widget */
-    combo = gtk_combo_box_new_text ();
+    combo = gtk_combo_box_text_new ();
 
     /* FIXME: Hamlib does also have 'user' */
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("AGC OFF"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Super Fast"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Fast"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Medium"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Slow"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Auto"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("AGC OFF"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Super Fast"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Fast"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Medium"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Slow"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Auto"));
 
     gtk_widget_set_tooltip_text (combo, _("Automatic Gain Control Level"));
 
@@ -291,7 +291,7 @@ rig_gui_ctrl2_create_mode_selector   ()
     gint         i,mode;
 
     /* create and initialize widget */
-    combo = gtk_combo_box_new_text ();
+    combo = gtk_combo_box_text_new ();
 
     /* loop over all modes */
     for (i = 0; i < 16; i++) {
@@ -303,8 +303,8 @@ rig_gui_ctrl2_create_mode_selector   ()
         */
         if (rig_data_get_all_modes () & mode) {
 
-            gtk_combo_box_append_text (GTK_COMBO_BOX (combo),
-                            _(midx2str[i]));
+            gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo),
+                                            _(midx2str[i]));
 
             midx2cidx[i] = index;
             cidx2mode[index] = mode;
@@ -353,13 +353,13 @@ rig_gui_ctrl2_create_filter_selector ()
 
 
     /* create and initialize widget */
-    combo = gtk_combo_box_new_text ();
+    combo = gtk_combo_box_text_new ();
 
     /* Add items */
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Wide"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Normal"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("Narrow"));
-    gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _("[User]"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Wide"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Normal"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("Narrow"));
+    gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), _("[User]"));
 
     /* set current passband width */
     switch (rig_data_get_pbwidth ()) {
@@ -427,8 +427,8 @@ rig_gui_ctrl2_create_antenna_selector   ()
 	gint         i,antenna;
 	gchar        antstr[16];
 
-	/* create and initialize widget */
-	combo = gtk_combo_box_new_text ();
+    /* create and initialize widget */
+    combo = gtk_combo_box_text_new ();
 
 	/* loop over all antennas */
 	for (i = 0; i < 8; i++) {
@@ -442,8 +442,8 @@ rig_gui_ctrl2_create_antenna_selector   ()
 
 			snprintf(antstr, sizeof(antstr)-1, _("ANT %d"), i+1);
 
-			gtk_combo_box_append_text (GTK_COMBO_BOX (combo),
-						   antstr);
+            gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo),
+                                            antstr);
 
 			midx2cidx[i] = index;
 			cidx2mode[index] = antenna;
@@ -452,9 +452,9 @@ rig_gui_ctrl2_create_antenna_selector   ()
 	}
 	
 
-	/* set current antenna */
-	gtk_combo_box_set_active (GTK_COMBO_BOX (combo),
-				  midx2cidx[rig_utils_mode_to_index (rig_data_get_antenna ())]);
+    /* set current antenna */
+    gtk_combo_box_set_active (GTK_COMBO_BOX (combo),
+                  midx2cidx[rig_utils_mode_to_index (rig_data_get_antenna ())]);
 
 	/* add tooltips when widget is realized */
     gtk_widget_set_tooltip_text (combo, _("Antenna Port"));

--- a/src/rig-gui-smeter.c
+++ b/src/rig-gui-smeter.c
@@ -406,14 +406,15 @@ rig_gui_mode_selector_create  ()
     guint i;
     guint modes = 0;
 
-    combo = gtk_combo_box_new_text ();
+    combo = gtk_combo_box_text_new ();
 
     /* Add entries to combo box; but only if rig supports it
        Also fill index_to_mode conversion table.
     */
     for (i = SMETER_TX_MODE_NONE; i < SMETER_TX_MODE_LAST; i++) {
         if (rig_gui_smeter_has_tx_mode (i)) {
-            gtk_combo_box_append_text (GTK_COMBO_BOX (combo), _(TX_MODE_S[i]));
+            gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo),
+                                            _(TX_MODE_S[i]));
             index_to_mode[modes] = i;
             modes++;
         }
@@ -450,11 +451,12 @@ rig_gui_scale_selector_create ()
     GtkWidget *combo;
     guint i;
 
-    combo = gtk_combo_box_new_text ();
+    combo = gtk_combo_box_text_new ();
 
     /* Add entries to combo box */
     for (i = SMETER_SCALE_5; i < SMETER_SCALE_LAST; i++) {
-        gtk_combo_box_append_text (GTK_COMBO_BOX (combo), TX_SCALE_S[i]);
+        gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo),
+                                        TX_SCALE_S[i]);
     }
 
     /* connect changed signal */


### PR DESCRIPTION
`gtk_combo_box_*` was dropped in GTK3, but the newer `gtk_combo_box_text_*` introduced in 2.24 was carried over to 3.

This will help support our migration to GTK3 in #13.