### PR TITLE
Port GTK2 drawing primitives to cairo

### DIFF
--- a/src/rig-gui-lcd.h
+++ b/src/rig-gui-lcd.h
@@ -67,6 +67,9 @@
 
 #define RIG_GUI_LCD_DEF_TVAL 400
 
+/** \brief define default font for LCD static text */
+#define RIG_GUI_LCD_FONT "Sans 10"
+
 /** \brief Coordinate structure for digits. */
 typedef struct {
 	guint x;     /*!< X coordinate. */
@@ -87,11 +90,9 @@ typedef struct {
  */
 typedef struct {
 	GtkWidget        *canvas;          /*!< The main canvas. */
-	GdkGC            *gc1;             /*!< Graphics context (normal). */
-	GdkGC            *gc2;             /*!< Graphics context (inverted). */
 	guint             width;           /*!< Canvas width. */
 	guint             height;          /*!< Canvas height. */
-	lcd_coor_t        digits[13];      /*!< Starting points for all digits. */
+	lcd_coor_t        digits[14];      /*!< Starting points for all digits. */
 	lcd_coor_t        dots[2];       /*!< Starting points for dots. */
 	guint             dlw;             /*!< Width of large digits. */
 	guint             dlh;             /*!< Height of large digits. */
@@ -109,11 +110,9 @@ typedef struct {
 	gdouble           freq1;           /*!< Main frequency value. */
 	gdouble           freq2;           /*!< Secondary frequency value. */
 	gdouble           freqm;           /*!< Manually entered frequency value. */
-	gchar             freqs1[10];      /*!< Frequency array. */
 	gint              rit;             /*!< Current RIT value. */
-	gchar             rits[4];         /*!< -9999 Hz but last digit not shown */
 	gint              xit;             /*!< Current XIT value. */
-	gchar             xits[4];         /*!< -9999 Hz but last digit not shown */
+    gboolean          dirty;           /*!< Wheter or not the LCD requires update */
 } lcd_t;
 
 

--- a/src/rig-gui-smeter.h
+++ b/src/rig-gui-smeter.h
@@ -11,24 +11,22 @@
     More details can be found at the project home page:
 
             http://groundstation.sourceforge.net/
- 
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-  
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-  
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, visit http://www.fsf.org/
- 
- 
- 
- 
+
 */
+
 /** \file rig-gui-smeter.h
  *  \ingroup smeter
  *  \brief Signal strength meter widget (interface).
@@ -62,6 +60,11 @@
 /** \brief Maximum falloff speed in deg/sec */
 #define RIG_GUI_SMETER_MAX_FALLOFF 500.0
 
+/** \brief Width of the meter widget */
+#define RIG_GUI_SMETER_WIDTH 160
+
+/** \brief Height of the meter widget */
+#define RIG_GUI_SMETER_HEIGHT 80
 
 /** \brief Scale setting for s-meter.
  *
@@ -106,7 +109,6 @@ typedef enum {
 typedef struct {
 	GtkWidget              *canvas;      /*!< The drawing area widget. */
 	GdkPixbuf              *pixbuf;      /*!< The background pixmap.   */
-	GdkGC                  *gc;          /*!< Graphics context for drawing. */
 	gboolean                exposed;     /*!< Flag to indicate whether canvas is ready. */
 	gfloat                  value;       /*!< Current value (angle).   */
 	gfloat                  lastvalue;   /*!< Previous value (angle).  */
@@ -122,5 +124,3 @@ smeter_tx_mode_t  rig_gui_smeter_get_tx_mode (void);
 
 
 #endif
-
-


### PR DESCRIPTION
Supporting #13. GTK3 drops support for `gdk_gc_*` and `gdk_draw_*` calls. These commits port those calls to use `cairo_*` and `gdk_cairo_*` functions which are supported in later versions of GTK2 as well as GTK3.

The LCD has been significantly refactored to centralise all drawing around the `rig_gui_lcd_expose_cb` function, separating it from widget state updates.

I have tested this as much as I can with Hamlib dummy and against my Icom 7300, however was unable to test VFO display updates - any additional testing around this would be appreciated!