### PR TITLE
docs: add Repology packaging status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ regardless of which radio they use.
 
 ![Grig screenshot](doc/images/screenshot.png)
 
+## Packaging status
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/grig.svg)](https://repology.org/project/grig/versions)
+
 ## Installing Grig from Source
 
 Assuming that you have obtained and unpacked source distribution, you can


### PR DESCRIPTION
Closes #23.

Adds a "Packaging status" section with the [vertical-allrepos](https://repology.org/badge/vertical-allrepos/grig.svg) badge from Repology, placed just before the source-install instructions. This shows which distros currently package grig and at which version, answering the issue's own question ("which distros have which version of grig") more directly than a simple repo-count badge would.

(Drafted with Claude Code's assistance, reviewed by me before submitting.)